### PR TITLE
replace README.md --> index.html with a redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,0 @@
-# juliaimages.github.io
-
-Documentation For JuliaImages
-
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliaimages.github.io/JuliaImages/stable)
-[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://juliaimages.github.io/JuliaImages/latest)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=http://juliaimages.github.io/latest" />
+  </head>
+</html>


### PR DESCRIPTION
As described in #4, visiting http://juliaimages.github.io/ rather than http://juliaimages.github.io/latest shows the contents of the README.md from the `master` branch.

Since on GitHub the default branch is already configured to be `source`, there's no need for a README in the `master` branch (the fact that it contains broken links to the docs further confirms that it was indeed not used as a README).

With this change, visiting http://juliaimages.github.io/ will automatically take people to http://juliaimages.github.io/latest rather than show them the rendered README page.