### PR TITLE
Update to julia 1.0; various fixes; add a "landing page" for demos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: julia
 os:
   - linux
 julia:
-  - 0.6
+  - 1.0
 notifications:
   email: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.add("Documenter"); Pkg.add("Images"); Pkg.add("Unitful"); Pkg.add("TestImages"); Pkg.add("ImageMagick"); Pkg.add("ImageFeatures"); Pkg.add("ImageDraw"); Pkg.clone("https://github.com/JuliaImages/ImageSegmentation.jl")'
+  - julia -e 'using Pkg; pkg"add Documenter Images AxisArrays Colors ColorTypes CoordinateTransformations Distances FileIO FixedPointNumbers ImageAxes ImageDraw ImageFeatures ImageFiltering ImageMagick ImageMetadata ImageSegmentation SimpleTraits TestImages Unitful"'
   - julia -e 'cd(ENV["TRAVIS_BUILD_DIR"]); ENV["DOCUMENTER_DEBUG"] = "true"; include(joinpath("docs", "make.jl"))'

--- a/README.md
+++ b/README.md
@@ -7,3 +7,14 @@ Documentation For [JuliaImages](https://github.com/JuliaImages), the organizatio
 Note that the source files for the documentation are on the `source`
 branch; `master` is used only for deploying the generated HTML
 content.
+
+## Adding demos
+
+Users are invited to add demonstrations carrying out particular tasks, for example like the gallery for [scikit-image](http://scikit-image.org/docs/stable/auto_examples/).
+The current procedure is as follows:
+
+- `git clone` a copy of this repository
+- Add a new [markdown file](https://en.wikipedia.org/wiki/Markdown) to `docs/src/demos` for your demo. Generally demos should contain one or more images, which should be added to `docs/src/assets/demos`. (If you have many images in your demo, consider creating a subdirectory for your images.)
+- Add a link to your demo in `docs/src/demos.md`, using one of the images you added as a "thumbnail" advertising your demo.
+- Build the documentation locally with `julia make.jl` from `docs/`. Inspect it to make sure all is well.
+- Commit your changes (including all new files) and submit a pull request.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ The current procedure is as follows:
 
 - `git clone` a copy of this repository
 - Add a new [markdown file](https://en.wikipedia.org/wiki/Markdown) to `docs/src/demos` for your demo. Generally demos should contain one or more images, which should be added to `docs/src/assets/demos`. (If you have many images in your demo, consider creating a subdirectory for your images.)
-- Add a link to your demo in `docs/src/demos.md`, using one of the images you added as a "thumbnail" advertising your demo.
+- Add a "card" for your demo in `docs/src/demos.md`, using one of the images you added as a "thumbnail" advertising your demo.
 - Build the documentation locally with `julia make.jl` from `docs/`. Inspect it to make sure all is well.
 - Commit your changes (including all new files) and submit a pull request.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,11 +24,11 @@ makedocs(format   = :html,
                      ],
          html_edit_branch = "source")
 
-deploydocs(repo    = "github.com/JuliaImages/juliaimages.github.io.git",
-           target  = "build",
-           branch  = "master",
-           latest  = "source",
-           julia   = "0.6",
-           osname  = "linux",
-           deps    = nothing,
-           make    = nothing)
+deploydocs(repo      = "github.com/JuliaImages/juliaimages.github.io.git",
+           target    = "build",
+           branch    = "master",
+           latest    = "source",
+           julia     = "1.0",
+           osname    = "linux",
+           deps      = nothing,
+           make      = nothing)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,6 +2,8 @@ using Documenter, Images, ImageFiltering, ImageSegmentation, ImageFeatures
 
 makedocs(format   = :html,
          sitename = "JuliaImages",
+         assets   = [joinpath("assets", "style.css"),
+                    ],
          pages    = ["Home"=>"index.md",
                      "install.md",
                      "Manual" => Any[
@@ -17,6 +19,7 @@ makedocs(format   = :html,
                          "troubleshooting.md",
                      ],
                      "Demos" => Any[
+                         "demos.md",
                          "demos/color_separations_svd.md",
                      ],
                      "function_reference.md",

--- a/docs/src/assets/style.css
+++ b/docs/src/assets/style.css
@@ -1,0 +1,3 @@
+table td img {
+    width: 200px;
+}

--- a/docs/src/assets/style.css
+++ b/docs/src/assets/style.css
@@ -1,3 +1,6 @@
-table td img {
-    width: 200px;
+.card-200 {
+    width:200px;
+    box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
+    transition: 0.3s;
+    border-radius: 5px; /* 5px rounded corners */
 }

--- a/docs/src/demos.md
+++ b/docs/src/demos.md
@@ -1,0 +1,15 @@
+# Color channels
+
+```@raw html
+<table>
+  <tbody>
+    <tr>
+      <td><a href="https://juliaimages.github.io/latest/demos/color_separations_svd.html"><img src="assets/demos/color_separations_svd.jpg" alt="SVD"></a></td>
+    </tr>
+  </tbody>
+</table>
+```
+
+# Contributions
+
+Users are invited to [contribute demonstrations of their own](https://github.com/JuliaImages/juliaimages.github.io).

--- a/docs/src/demos.md
+++ b/docs/src/demos.md
@@ -1,15 +1,30 @@
-# Color channels
+# Demonstrations
+
+## Color channels
 
 ```@raw html
-<table>
-  <tbody>
-    <tr>
-      <td><a href="https://juliaimages.github.io/latest/demos/color_separations_svd.html"><img src="assets/demos/color_separations_svd.jpg" alt="SVD"></a></td>
-    </tr>
-  </tbody>
-</table>
+<div class="cards">
 ```
 
-# Contributions
+```@raw html
+<div class="card-200">
+<div class="card-img">
+```
+[![svd](assets/demos/color_separations_svd.jpg)](@ref color_separations_svd)
+```@raw html
+</div>
+<div class="card-text">
+```
+[Color separations and SVD](@ref color_separations_svd)
+```@raw html
+</div>
+</div>
+```
+
+```@raw html
+</div>
+```
+
+## Contributions
 
 Users are invited to [contribute demonstrations of their own](https://github.com/JuliaImages/juliaimages.github.io).

--- a/docs/src/demos/color_separations_svd.md
+++ b/docs/src/demos/color_separations_svd.md
@@ -1,4 +1,4 @@
-# Color separations and the SVD
+# [Color separations and the SVD](@id color_separations_svd)
 
 This demonstration shows how to work with color channels and build a
 simple GUI to explore image compression using the Singular Value

--- a/docs/src/demos/color_separations_svd.md
+++ b/docs/src/demos/color_separations_svd.md
@@ -5,24 +5,23 @@ simple GUI to explore image compression using the Singular Value
 Decomposition (SVD).
 
 ```julia
-using Images, TestImages, Interact
+using Images, TestImages, LinearAlgebra, Interact
 
 img = testimage("mandrill")
-
 channels = float(channelview(img))
-
-function rank_approx(M, k)
-    U, S, V = svd(M)
+function rank_approx(F::SVD, k)
+    U, S, V = F
     M = U[:, 1:k] * Diagonal(S[1:k]) * V[:, 1:k]'
     M = min.(max.(M, 0.0), 1.)
 end
+svdfactors = (svd(channels[1,:,:]), svd(channels[2,:,:]), svd(channels[3,:,:]))
 
 n = 100
 @manipulate for k1 in 1:n, k2 in 1:n, k3 in 1:n
     colorview(RGB,
-              rank_approx(channels[1,:,:], k1),
-              rank_approx(channels[2,:,:], k2),
-              rank_approx(channels[3,:,:], k3)
+              rank_approx(svdfactors[1], k1),
+              rank_approx(svdfactors[2], k2),
+              rank_approx(svdfactors[3], k3)
               )
 end
 ```

--- a/docs/src/function_reference.md
+++ b/docs/src/function_reference.md
@@ -26,9 +26,7 @@ images.
 
 ```@docs
 colorview
-ColorView
 channelview
-ChannelView
 normedview
 rawview
 permuteddimsview

--- a/docs/src/imageaxes.md
+++ b/docs/src/imageaxes.md
@@ -17,12 +17,7 @@ dealing with such images.
 
 ## Installation
 
-If you've installed the `Images` packages, `ImageAxes` should already
-be installed for you. If not, add it with
-
-```jl
-Pkg.add("ImageAxes")
-```
+If you want to directly use `ImageAxes`, `add` it via the package manager.
 
 ## Usage
 
@@ -85,8 +80,8 @@ You can also specialize methods like this:
 
 ```@example
 using ImageAxes, SimpleTraits
-@traitfn nimages{AA<:AxisArray;  HasTimeAxis{AA}}(img::AA) = length(timeaxis(img))
-@traitfn nimages{AA<:AxisArray; !HasTimeAxis{AA}}(img::AA) = 1
+@traitfn nimages(img::AA) where {AA<:AxisArray;  HasTimeAxis{AA}} = length(timeaxis(img))
+@traitfn nimages(img::AA) where {AA<:AxisArray; !HasTimeAxis{AA}} = 1
 ```
 
 where the pre-defined `HasTimeAxis` trait will restrict that method to

--- a/docs/src/imagefeatures.md
+++ b/docs/src/imagefeatures.md
@@ -29,14 +29,13 @@ this example.
 First, let us create the two images we will match using BRISK.
 
 ```@example 3
-
 using ImageFeatures, TestImages, Images, ImageDraw, CoordinateTransformations
 
 img = testimage("lighthouse")
 img1 = Gray.(img)
 rot = recenter(RotMatrix(5pi/6), [size(img1)...] .÷ 2)  # a rotation around the center
 tform = rot ∘ Translation(-50, -40)
-img2 = warp(img1, tform, indices(img1))
+img2 = warp(img1, tform, axes(img1))
 nothing # hide
 ```
 

--- a/docs/src/imagesegmentation.md
+++ b/docs/src/imagesegmentation.md
@@ -216,14 +216,14 @@ This algorithm operates on a Region Adjacency Graph (RAG). Each pixel/region is 
 ###### Demo
 
 ```julia
-using Images, ImageSegmentation, TestImages;
+using Images, ImageSegmentation, TestImages, Random
 
 img = Gray.(testimage("house"));
 segments = felzenszwalb(img, 300, 100); # k=300 (the merging threshold), min_size = 100 (smallest number of pixels/region)
 
 # visualize segmentation by creating an image with each label replaced by a random color
 function get_random_color(seed)
-    srand(seed)
+    Random.seed!(seed)
     rand(RGB{N0f8})
 end
 imshow(map(i->get_random_color(i), labels_map(segments)))

--- a/docs/src/imagesegmentation.md
+++ b/docs/src/imagesegmentation.md
@@ -393,13 +393,15 @@ J = \displaystyle\sum_{i=1}^{N} \sum_{j=1}^{C} \delta_{ij} \| x_{i} - c_{j} \|^2
 
 Unlike K-means, it allows pixels to belong to two or more clusters. It is widely used
 for medical imaging like in the soft segmentation of brain tissue model.
+Note that both Fuzzy C-means and K-means have an element of randomness, and it's possible
+to get results that vary considerably from one run to the next.
 
 **Time Complexity:** ``O(n*C^2*iter)`` where ``n`` is the number of pixels, ``C`` is
 number of clusters and ``iter`` is the number of iterations.
 
 ###### Demo
 
-```jldoctest
+```jldoctest; filter=r"converged in [0-9]+ iterations"
 julia> using ImageSegmentation, Images
 
 julia> img = load("src/assets/segmentation/flower.jpg");
@@ -407,6 +409,13 @@ julia> img = load("src/assets/segmentation/flower.jpg");
 julia> r = fuzzy_cmeans(img, 3, 2)
 FuzzyCMeansResult: 3 clusters for 135360 points in 3 dimensions (converged in 27 iterations)
 ```
+
+Briefly, `r` contains two fields of interest:
+
+- `centers`, a `3×C` matrix of center positions for `C` clusters in RGB colorspace. You can extract it as a vector of colors using `centers = colorview(RGB, r.centers)`.
+- `weights`, a `n×C` matrix such that `r.weights[10,2]` would be the weight of the 10th pixel in the green color channel (color channel 2).  You can visualize this component as `centers[i]*reshape(r.weights[:,i], axes(img))`.
+
+See the documentation in [Clustering.jl](https://github.com/JuliaStats/Clustering.jl) for further details.
 
 **Original** [(source)](https://upload.wikimedia.org/wikipedia/commons/thumb/d/d9/Flower-631765_960_720.jpg/800px-Flower-631765_960_720.jpg)
 

--- a/docs/src/indexing.md
+++ b/docs/src/indexing.md
@@ -22,24 +22,23 @@ overlay the two images
 ([Using colorview to make color overlays](@ref)) to see how well we're
 doing.
 
-```julia
-# Define the transformation, using CoordinateTransformations
-# We're rotating around the center of img
-julia> tfm = recenter(RotMatrix(pi/8), center(img))
-AffineMap([0.92388 -0.382683; 0.382683 0.92388], [88.7786,-59.3199])
+```jldoctest; setup = :(using Images; img = load(joinpath(@__DIR__, "src/assets/indexing/cmrot.png")))
+julia> using Images, CoordinateTransformations
 
-# Apply it to the image
+julia> tfm = recenter(RotMatrix(pi/8), center(img))
+AffineMap([0.92388 -0.382683; 0.382683 0.92388], [88.7786, -59.3199])
+
 julia> imgrot = warp(img, tfm);
 
 julia> summary(img)
-"386×386 Array{Gray{N0f8},2}"
+"386×386 Array{Gray{N0f8},2} with eltype Gray{Normed{UInt8,8}}"
 
 julia> summary(imgrot)
-"-59:446×-59:446 OffsetArray{Gray{Float64},2}"
+"OffsetArray(::Array{Gray{N0f8},2}, -59:446, -59:446) with eltype Gray{Normed{UInt8,8}} with indices -59:446×-59:446"
 ```
 
-While `img` has indices that start with the conventional 1, the
-summary of `imgrot` reports that it has indices `(-59:446, -59:446)`.
+While `img` has axes that start with the conventional 1, the
+summary of `imgrot` reports that it has axes `(-59:446, -59:446)`.
 This means that the first element of `imgrot` is indexed with
 `imgrot[-59,-59]` and the last element with `imgrot[446,446]`.
 
@@ -78,26 +77,24 @@ You can learn more about Julia's support for arbitrary indices in
 ## Keeping track of orientation with named axes
 
 Suppose you are presented with a 3-dimensional grayscale image. Is this a movie (2d over time), or a 3d image (x, y, and z)? In such situations, one of the best ways to keep yourself oriented is by naming the axes.
+The TestImages package contains an example of a file that illustrates this:
 
-```julia
+```jldoctest
 julia> using Images, TestImages
 
 julia> img = testimage("mri");
 
-# Create a "labeled image"
-julia> imgl = AxisArray(img, :A, :R, :S)
-3-dimensional AxisArray{ColorTypes.Gray{FixedPointNumbers.Normed{UInt8,8}},3,...} with axes:
-    :A, Base.OneTo(226)
-    :R, Base.OneTo(186)
-    :S, Base.OneTo(27)
-And data, a 226×186×27 Array{ColorTypes.Gray{FixedPointNumbers.Normed{UInt8,8}},3}:
-[:, :, 1] =
- Gray{N0f8}(0.0)  Gray{N0f8}(0.0)  Gray{N0f8}(0.0)  Gray{N0f8}(0.0)  …  Gray{N0f8}(0.0)  Gray{N0f8}(0.0)  Gray{N0f8}(0.0)  Gray{N0f8}(0.0)
- Gray{N0f8}(0.0)  Gray{N0f8}(0.0)  Gray{N0f8}(0.0)  Gray{N0f8}(0.0)     Gray{N0f8}(0.0)  Gray{N0f8}(0.0)  Gray{N0f8}(0.0)  Gray{N0f8}(0.0)
-...
+julia> println(summary(img))
+3-dimensional AxisArray{Gray{N0f8},3,...} with axes:
+    :P, 0:1:225
+    :R, 0:1:185
+    :S, 0:5:130
+And data, a 226×186×27 Array{Gray{N0f8},3} with eltype Gray{Normed{UInt8,8}}
 ```
 
-Here we used the [AxisArrays package](https://github.com/JuliaArrays/AxisArrays.jl) to name our axes in terms of the [RAS coordinate system](http://www.grahamwideman.com/gw/brain/orientation/orientterms.htm) (Right, Anterior, Superior) as commonly used in magnetic resonance imaging.
+TestImages uses the [AxisArrays package](https://github.com/JuliaArrays/AxisArrays.jl) to name the axes of
+this particular image in terms of the [RAS coordinate system](http://www.grahamwideman.com/gw/brain/orientation/orientterms.htm) (Right, Anterior, Superior) as commonly used in magnetic resonance imaging.
+See the documentation for that package to learn more about how you can create your own `AxisArray` objects.
 
 We can use this coordinate system to help with visualization. Let's look at a "horizontal slice," one perpendicular to the superior-inferior axis (i.e., a slice with constant `S` value):
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -5,10 +5,10 @@ much (but not all) of the functionality in JuliaImages.
 
 ## Installation
 
-Install Images via the package manager,
+Install Images via the [package manager](https://docs.julialang.org/en/v1/stdlib/Pkg/),
 
 ```julia
-Pkg.add("Images")
+(v1.0) pkg> add Images
 ```
 
 This will also install many dependencies.
@@ -22,11 +22,11 @@ ensuring that you can load and display images.
 When testing ideas or just following along with the documentation, it can be
 useful to have some images to work with.
 The [TestImages](https://github.com/JuliaImages/TestImages.jl) package bundles several "standard" images for you.
+If you haven't already installed it, use `pkg> add TestImages`.
 
 To load one of the images from this package, say
 
 ```julia
-Pkg.add("TestImages")    # if you haven't already installed this package
 using TestImages
 img = testimage("mandrill")
 ```
@@ -38,7 +38,7 @@ the recommendation, unless you have reasons to prefer an alternate
 solution.
 
 For loading image files that might already be on your computer, you should
-(if you installed Images) already have the [FileIO
+use the [FileIO
 package](https://github.com/JuliaIO/FileIO.jl):
 
 ```julia
@@ -52,8 +52,7 @@ an input/output package appropriate for your platform.
 ## Displaying images
 
 When working with images, it's obviously helpful to be able to look at
-them.  If you use Julia through [Juno](http://junolab.org/) (**FIXME:
-figure out Juno**) or
+them.  If you use Julia through [Juno](http://junolab.org/) or
 [IJulia](https://github.com/JuliaLang/IJulia.jl), images should
 display automatically:
 
@@ -62,7 +61,6 @@ display automatically:
 Users of the Julia command-line interface (REPL) can install the [ImageView](https://github.com/timholy/ImageView.jl) package:
 
 ```julia
-Pkg.add("ImageView")
 using TestImages, Images, ImageView
 img = testimage("mandrill")
 imshow(img)

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -177,6 +177,10 @@ it straightforward to keep track of the correspondence between
 location across multiple images. More information can be found in
 [Keeping track of location with unconventional indices](@ref).
 
+## Examples of usage
+
+If you feel ready to get started, see the [Demonstrations](@ref) page for inspiration.
+
 ## Function categories
 
 See [Summary and function reference](@ref) for more information about

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -12,8 +12,7 @@ For most purposes, any `AbstractArray` can be treated as an image. For example,
 ```jldoctest; output = false
 using Images
 
-img = rand(640,480)               # a random Float64 image
-img = rand(RGB{N0f8}, 256, 256)   # a random RGB image, 8 bits per channel
+img = rand(640,480)               # a random Float64 image (grayscale)
 # select a region-of-interest from a larger image
 imgc = img[200:245, 17:42]        # makes a copy
 imgv = @view img[200:245, 17:42]  # makes a view
@@ -80,7 +79,20 @@ In such cases the representation of a single pixel is spread out among
 In JuliaImages, the typical representation of such an image would be
 an `m × n` array of `RGB` values.
 Consequently, every element of the array corresponds to one pixel,
-and conversely each pixel is represented by exactly one array element.
+and conversely each pixel is represented by exactly one array element:
+
+```jldoctest
+using Images, TestImages
+
+img = testimage("mandrill")
+img[350,225]    # pick a reddish pixel from the nose of the mandrill
+
+# output
+
+RGB{N0f8}(0.937,0.294,0.231)
+```
+
+(In ImageView, you can "hover" over pixels and see their coordinates in the statusbar.)
 
 This design choice facilitates generic code that can handle both
 grayscale and color images without needing to introduce extra loops or

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -9,7 +9,7 @@ more detailed explanations in the following sections.
 
 For most purposes, any `AbstractArray` can be treated as an image. For example,
 
-```julia
+```jldoctest; output = false
 using Images
 
 img = rand(640,480)               # a random Float64 image
@@ -18,23 +18,34 @@ img = rand(RGB{N0f8}, 256, 256)   # a random RGB image, 8 bits per channel
 imgc = img[200:245, 17:42]        # makes a copy
 imgv = @view img[200:245, 17:42]  # makes a view
 # an image that starts black in the upper left and gets bright in the lower right:
-img = reshape(linspace(0,1,10^4), 100, 100)
+img = reshape(range(0,stop=1,length=10^4), 100, 100)
 # a 3d box image
 img = zeros(128, 128, 80)
-img[20:100, 20:100, 10:70] = 1
+img[20:100, 20:100, 10:70] .= 1
+maximum(img)
+
+# output
+
+1.0
 ```
 
 Some add-on packages enable additional behavior. For example,
 
-```julia
+```jldoctest
 using Images, Unitful, AxisArrays
 using Unitful: mm, s
 
-img = AxisArray(rand(256, 256, 100, 50), (:x, :y, :z, :time), (0.4mm, 0.4mm, 1mm, 2s))
+img = AxisArray(rand(256, 256, 6, 50), (:x, :y, :z, :time), (0.4mm, 0.4mm, 1mm, 2s));
+pixelspacing(img)
+
+# output
+
+(0.4 mm, 0.4 mm, 1 mm)
 ```
 
 defines a 4d image (3 space dimensions plus one time dimension) with
 the specified name and physical pixel spacing for each coordinate.
+(Note that [`pixelspacing`](@ref) only returns dimensions for spatial coordinates.)
 The AxisArrays package supports rich and efficient operations on such
 arrays, and can be useful to keep track of not just pixel spacing but
 the
@@ -60,7 +71,58 @@ It is very easy to define new array types in Julia--and consequently
 specialized images or operations--and have them interoperate
 smoothly with the vast majority of functions in JuliaImages.
 
-## Colors, the 0-to-1 intensity scale, and views
+## Array elements are pixels (and vice versa)
+
+In some languages, an RGB image is represented as an `m × n × 3` array,
+where the third dimension is the color-channel dimension.
+In such cases the representation of a single pixel is spread out among
+3 array elements.
+In JuliaImages, the typical representation of such an image would be
+an `m × n` array of `RGB` values.
+Consequently, every element of the array corresponds to one pixel,
+and conversely each pixel is represented by exactly one array element.
+
+This design choice facilitates generic code that can handle both
+grayscale and color images without needing to introduce extra loops or
+checks for a color dimension.
+It also provides more rational support for 3d grayscale images--which
+might happen to have size 3 along the third dimension--and
+consequently helps unify the "computer vision" and "biomedical image
+processing" communities.
+
+Because images are just arrays, some environments (e.g.,
+Juno or IJulia/Jupyter) will display numeric arrays as arrays using a text
+representation but will display 2d arrays that have `Colorant`
+elements as images.  You can "convert" in the following ways:
+
+```jldoctest
+using Images
+
+# "Convert" a numeric array to a `Colorant` (but grayscale) array
+A = rand(8, 8)
+img = Gray.(A)               # creates a copy of the data
+img = colorview(Gray, A)     # creates a "view" which "reinterprets" but does not copy data
+
+# RGB images
+A = rand(3, 8, 8)            # Float64 data (64 bits per color channel)
+img = colorview(RGB, A)      # encodes as a 2d RGB{Float64} array
+A = rand(N0f8, 3, 8, 8)      # uses only 8 bits per channel
+img = colorview(RGB, A)      # encodes as a 2d RGB{Float64} array
+
+# The following illustrates "conversions" between representation as an 8-bit RGB
+# image and as a 3×m×n UInt8 array
+A = rand(UInt8, 3, 8, 8)
+img = colorview(RGB, normedview(A))
+A = rand(RGB{N0f8}, 8, 8)
+A = rawview(channelview(A))
+eltype(A)
+
+# output
+
+UInt8
+```
+
+## The 0-to-1 intensity scale
 
 In JuliaImages, by default all images are displayed assuming that 0
 means "black" and 1 means "white" or "saturated" (the latter applying
@@ -80,25 +142,6 @@ images, and avoids the need for special conversion functions that
 change the *value* of pixels when your main goal is simply to change
 the *type* (numeric precision and properties) used to represent the
 pixel.
-
-Because images are just arrays, some environments (e.g.,
-IJulia/Jupyter) will display numeric arrays as arrays (using a text
-representation) but will display 2d arrays that have `Colorant`
-elements as images.  You can "convert" in the following ways:
-
-```julia
-img = colorview(Gray, rand(8, 8))          # encodes as Gray{Float64}, so displays as image
-img = colorview(RGB, rand(3, 8, 8))        # encodes as a 2d RGB{Float64} array
-img = colorview(RGB, rand(N0f8, 3, 8, 8))  # uses only 8 bits per channel
-# The following two "convert" between representation as an 8-bit RGB
-# image and as a 3×m×n UInt8 array
-img = colorview(RGB, normedview(A))
-A = rawview(channelview(rand(RGB{N0f8}, 8, 8)))
-```
-
-All of these "conversions" actually create views, meaning that no
-copies of the underlying storage are made unless you call `copy` on
-the result.
 
 ## Default orientation and storage order
 
@@ -159,7 +202,5 @@ Test images and phantoms (see also TestImages.jl):
 
 - `shepp_logan`
 
-See also the excellent
-[ImageFeatures](http://juliaimages.github.io/ImageFeatures.jl/latest/)
-package, which supports a number of algorithms important for computer
-vision.
+Also described are the [ImageFeatures.jl](@ref) and [ImageSegmentation.jl](@ref) packages,
+which support a number of algorithms important for computer vision.


### PR DESCRIPTION
I believe this may be the last step to bring JuliaImages into the 1.0 era!

This updates the docs to use julia-1.0 (fixes #27), and in the mean time fixes a number of other issues.

Going forward, one of the things I most want is a collection of demos like the ones in [scikit-image](http://scikit-image.org/docs/stable/auto_examples/). This should be a community effort. I've tried to kick-start the process by providing some instructions and creating a (primitive) thumbnails page. Improvements either to the infrastructure, or by adding more demos, would be greatly appreciated.