### PR TITLE
Document StackedViews

### DIFF
--- a/docs/src/conversions_views.md
+++ b/docs/src/conversions_views.md
@@ -412,26 +412,42 @@ information.
 
 ## StackedViews
 
-Sometimes it's helpful to combine several images into a single view for 
-further array like manipulation. 
+Sometimes it's helpful to combine several images into a single view for
+further array-like manipulation.
+
 ```jldoctest; setup = :(using Images)
+julia> img1 = reshape(1:8, (2,4))
+2×4 reshape(::UnitRange{Int64}, 2, 4) with eltype Int64:
+ 1  3  5  7
+ 2  4  6  8
 
-julia> img1 = ImageMeta(reshape(1:1:8, (2,2,2)))
-Int64 ImageMeta with:
-  data: 2×2×2 reshape(::StepRange{Int64,Int64}, 2, 2, 2) with eltype Int64
-  properties:
+julia> img2 = reshape(11:18, (2,4))
+2×4 reshape(::UnitRange{Int64}, 2, 4) with eltype Int64:
+ 11  13  15  17
+ 12  14  16  18
 
-julia> img2 = ImageMeta(reshape(2:1:9, (2,2,2)))
-Int64 ImageMeta with:
-  data: 2×2×2 reshape(::StepRange{Int64,Int64}, 2, 2, 2) with eltype Int64
-  properties:
+julia> sv = StackedView(img1, img2)
+2×2×4 StackedView{Int64,3,Tuple{Base.ReshapedArray{Int64,2,UnitRange{Int64},Tuple{}},Base.ReshapedArray{Int64,2,UnitRange{Int64},Tuple{}}}}:
+[:, :, 1] =
+  1   2
+ 11  12
 
-julia> sv = StackedView(img1, img2);
+[:, :, 2] =
+  3   4
+ 13  14
+
+[:, :, 3] =
+  5   6
+ 15  16
+
+[:, :, 4] =
+  7   8
+ 17  18
 
 julia> imgMatrix = reshape(sv, (2, 8))
-2×8 reshape(::StackedView{Int64,4,Tuple{ImageMeta{Int64,3,Base.ReshapedArray{Int64,3,StepRange{Int64,Int64},Tuple{}}},ImageMeta{Int64,3,Base.ReshapedArray{Int64,3,StepRange{Int64,Int64},Tuple{}}}}}, 2, 8) with eltype Int64:
- 1  2  3  4  5  6  7  8
- 2  3  4  5  6  7  8  9
+2×8 reshape(::StackedView{Int64,3,Tuple{Base.ReshapedArray{Int64,2,UnitRange{Int64},Tuple{}},Base.ReshapedArray{Int64,2,UnitRange{Int64},Tuple{}}}}, 2, 8) with eltype Int64:
+  1   2   3   4   5   6   7   8
+ 11  12  13  14  15  16  17  18
 ```
 
 ## Decoupling views from the parent memory

--- a/docs/src/conversions_views.md
+++ b/docs/src/conversions_views.md
@@ -410,6 +410,29 @@ compare two (or more) grayscale images. See
 [Keeping track of location with unconventional indices](@ref) for more
 information.
 
+## StackedViews
+
+Sometimes it's helpful to combine several images into a single view for 
+further array like manipulation. 
+```jldoctest; setup = :(using Images)
+julia> img1 = ImageMeta(rand(2,2,2))
+Float64 ImageMeta with:
+  data: 2×2×2 Array{Float64,3}
+  properties:
+
+julia> img2 = ImageMeta(rand(2,2,2))
+Float64 ImageMeta with:
+  data: 2×2×2 Array{Float64,3}
+  properties:
+
+julia> sv = StackedView(img1, img2);
+
+julia> imgMatrix = reshape(sv, (2, prod(size(img1))))
+2×8 reshape(::StackedView{Float64,4,Tuple{ImageMeta{Float64,3,Array{Float64,3}},ImageMeta{Float64,3,Array{Float64,3}}}}, 2, 8) with eltype Float64:
+ 0.146778  0.833466  0.0380765  0.930426  0.623228  0.692244  0.344908  0.335563
+ 0.530886  0.335896  0.502504   0.523674  0.380827  0.149471  0.749996  0.567014
+```
+
 ## Decoupling views from the parent memory
 
 If you want to use some of these views but have an application where

--- a/docs/src/conversions_views.md
+++ b/docs/src/conversions_views.md
@@ -415,22 +415,23 @@ information.
 Sometimes it's helpful to combine several images into a single view for 
 further array like manipulation. 
 ```jldoctest; setup = :(using Images)
-julia> img1 = ImageMeta(rand(2,2,2))
-Float64 ImageMeta with:
-  data: 2×2×2 Array{Float64,3}
+
+julia> img1 = ImageMeta(reshape(1:1:8, (2,2,2)))
+Int64 ImageMeta with:
+  data: 2×2×2 reshape(::StepRange{Int64,Int64}, 2, 2, 2) with eltype Int64
   properties:
 
-julia> img2 = ImageMeta(rand(2,2,2))
-Float64 ImageMeta with:
-  data: 2×2×2 Array{Float64,3}
+julia> img2 = ImageMeta(reshape(2:1:9, (2,2,2)))
+Int64 ImageMeta with:
+  data: 2×2×2 reshape(::StepRange{Int64,Int64}, 2, 2, 2) with eltype Int64
   properties:
 
 julia> sv = StackedView(img1, img2);
 
-julia> imgMatrix = reshape(sv, (2, prod(size(img1))))
-2×8 reshape(::StackedView{Float64,4,Tuple{ImageMeta{Float64,3,Array{Float64,3}},ImageMeta{Float64,3,Array{Float64,3}}}}, 2, 8) with eltype Float64:
- 0.146778  0.833466  0.0380765  0.930426  0.623228  0.692244  0.344908  0.335563
- 0.530886  0.335896  0.502504   0.523674  0.380827  0.149471  0.749996  0.567014
+julia> imgMatrix = reshape(sv, (2, 8))
+2×8 reshape(::StackedView{Int64,4,Tuple{ImageMeta{Int64,3,Base.ReshapedArray{Int64,3,StepRange{Int64,Int64},Tuple{}}},ImageMeta{Int64,3,Base.ReshapedArray{Int64,3,StepRange{Int64,Int64},Tuple{}}}}}, 2, 8) with eltype Int64:
+ 1  2  3  4  5  6  7  8
+ 2  3  4  5  6  7  8  9
 ```
 
 ## Decoupling views from the parent memory


### PR DESCRIPTION
This is #31 with a couple of tweaks. I'm not quite sure why there were still `doctest` errors, but my (surprising) hunch it was the blank line after the ` ```jldoctest``` `. In the course of debugging I switched from ImageMeta to plain ranges, in case it had something to do with the more complex output of an ImageMeta. Since that type isn't introduced until later in the documentation anyway, that's probably good on its own.

@Tokazama, if you approve I will squash this and merge it giving you credit for the PR.