### PR TITLE
upgrade to Documenter v0.22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ notifications:
   email: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'using Pkg; pkg"add Documenter Images AxisArrays Colors ColorTypes CoordinateTransformations Distances FileIO FixedPointNumbers ImageAxes ImageDraw ImageFeatures ImageFiltering ImageMagick ImageMetadata ImageSegmentation SimpleTraits TestImages Unitful"'
+  - julia -e 'using Pkg; pkg"add Documenter Images AxisArrays Colors ColorTypes CoordinateTransformations Distances FileIO FixedPointNumbers ImageAxes ImageDraw ImageFeatures ImageFiltering ImageMagick ImageMetadata ImageSegmentation SimpleTraits TestImages Unitful PaddedViews"'
   - julia --color=yes -e 'cd(ENV["TRAVIS_BUILD_DIR"]); ENV["DOCUMENTER_DEBUG"] = "true"; include(joinpath("docs", "make.jl"))'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,11 +1,10 @@
 using Documenter, Images, ImageFiltering, ImageSegmentation, ImageFeatures, PaddedViews
 
-makedocs(modules = [Images, ImageCore, Colors, ColorTypes, FixedPointNumbers, ImageAxes,
+makedocs(modules  = [Images, ImageCore, Colors, ColorTypes, FixedPointNumbers, ImageAxes,
                     ImageFeatures, ImageFiltering, ImageMetadata,
-                    ImageSegmentation, ImageTransformations, PaddedViews, ImageMorphology
-                    ],
-         format = Documenter.HTML(edit_branch = "source",
-                             assets = [joinpath("assets", "style.css")]);
+                    ImageSegmentation, ImageTransformations, PaddedViews, ImageMorphology],
+         format   = Documenter.HTML(edit_branch = "source",
+                                    assets = [joinpath("assets", "style.css")]),
          sitename = "JuliaImages",
          pages    = ["Home" => "index.md",
                      "install.md",
@@ -21,14 +20,14 @@ makedocs(modules = [Images, ImageCore, Colors, ColorTypes, FixedPointNumbers, Im
                          "imagefeatures.md",
                          "troubleshooting.md",
                      ],
-                    "Demos" => Any[
-                        "demos.md",
-                        "demos/color_separations_svd.md",
-			            "demos/rgb_hsv_thresholding.md",
+                     "Demos" => Any[
+                         "demos.md",
+                         "demos/color_separations_svd.md",
+                         "demos/rgb_hsv_thresholding.md",
                      ],
                      "function_reference.md",
                      "api_comparison.md",
-                     ])
+                    ])
 
 deploydocs(repo      = "github.com/JuliaImages/juliaimages.github.io.git",
            target    = "build",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,10 +1,13 @@
-using Documenter, Images, ImageFiltering, ImageSegmentation, ImageFeatures
+using Documenter, Images, ImageFiltering, ImageSegmentation, ImageFeatures, PaddedViews
 
-makedocs(format = :html,
-         sitename = "JuliaImages",
-         assets   = [joinpath("assets", "style.css"),
+makedocs(modules = [Images, ImageCore, Colors, ColorTypes, FixedPointNumbers, ImageAxes,
+                    ImageFeatures, ImageFiltering, ImageMetadata,
+                    ImageSegmentation, ImageTransformations, PaddedViews, ImageMorphology
                     ],
-         pages    = ["Home"=>"index.md",
+         format = Documenter.HTML(edit_branch = "source",
+                             assets = [joinpath("assets", "style.css")]);
+         sitename = "JuliaImages",
+         pages    = ["Home" => "index.md",
                      "install.md",
                      "Manual" => Any[
                          "quickstart.md",
@@ -18,21 +21,18 @@ makedocs(format = :html,
                          "imagefeatures.md",
                          "troubleshooting.md",
                      ],
-                     "Demos" => Any[
-                         "demos.md",
-                         "demos/color_separations_svd.md",
-			 "demos/rgb_hsv_thresholding.md",
+                    "Demos" => Any[
+                        "demos.md",
+                        "demos/color_separations_svd.md",
+			            "demos/rgb_hsv_thresholding.md",
                      ],
                      "function_reference.md",
                      "api_comparison.md",
-                     ],
-         html_edit_branch = "source")
+                     ])
 
 deploydocs(repo      = "github.com/JuliaImages/juliaimages.github.io.git",
            target    = "build",
            branch    = "master",
-           latest    = "source",
-           julia     = "1.0",
-           osname    = "linux",
+           devbranch = "source",
            deps      = nothing,
            make      = nothing)

--- a/docs/src/function_reference.md
+++ b/docs/src/function_reference.md
@@ -380,7 +380,7 @@ match_keypoints
 
 #### Gray Level Co-occurence Matrix
 
-```@docs
+```julia
 glcm
 glcm_symmetric
 glcm_norm
@@ -401,7 +401,7 @@ glcm_var_neighbour
 
 #### Local Binary Patterns
 
-```@docs
+```julia
 lbp
 modified_lbp
 direction_coded_lbp


### PR DESCRIPTION
This is a temporary patch, but it's necessary to be merged to test if autodeploy works.

* fix https://github.com/JuliaImages/juliaimages.github.io/issues/44  `[ Info: skipping docs deployment` by removing deprecated `deploydocs` keywords -- https://github.com/JuliaImages/juliaimages.github.io/issues/44#issuecomment-477856818
* fix `Warning: no doc found for reference * in src/function_reference.md` by add `modules` keywords to `makedocs` -- [the meaning of `modules`](https://juliadocs.github.io/Documenter.jl/stable/lib/public/#Documenter.makedocs)
* temporary change `@docs` of some undocumented `ImageFeatures` functions to `julia` -- https://github.com/JuliaImages/ImageFeatures.jl/issues/61

other issue @zygmuntszpak :
* crossreference warnings of `ImageFiltering` and `ImageSegmentation` still exist when build locally -- I can't find the reason why this breaks, actually, I don't even know what is broken in https://juliaimages.org/latest/function_reference.html.
