### PR TITLE
add installation note on proxy

### DIFF
--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -17,6 +17,10 @@ Images (and possibly some additional packages) may be all you need to manipulate
 However, most users will want to take one or two additional steps:
 ensuring that you can load and display images.
 
+!!! note
+    People in some regions such as China might fail installing/precompiling `Images` due to poor network
+    status. Using proxy/VPN that has stable connection to Amazon S3 and Github can solve this issue.
+
 ## Loading your first image
 
 When testing ideas or just following along with the documentation, it can be

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -18,7 +18,7 @@ However, most users will want to take one or two additional steps:
 ensuring that you can load and display images.
 
 !!! note
-    People in some regions such as China might fail installing/precompiling `Images` due to poor network
+    People in some regions such as China might fail to install/precompile `Images` due to poor network
     status. Using proxy/VPN that has stable connection to Amazon S3 and Github can solve this issue.
 
 ## Loading your first image


### PR DESCRIPTION
Some packages require downloading binary files from AWS S3 during the building process. However, in China networks to AWS S3 are extremely unstable and slow. New users will frequently meet issues like https://discourse.juliacn.com/t/topic/2420

Adding this note tells new Julia users from China that this isn't because `Images` is broken, it's just a network issue (GFW).