### PR TITLE
remove outdated ImageView warning

### DIFF
--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -311,12 +311,6 @@ Currently there're five julia packages can be used to display an image:
 * [`Plots`](https://github.com/JuliaPlots/Plots.jl) maintained by JuliaPlots is a general plotting package that support image display.
 * [`Makie`](https://github.com/JuliaPlots/Makie.jl) is also maintained by JuliaPlots but provides rich interactive functionality. 
 
-!!! warning
-    Currently `ImageView` is not fully tested on MacOS and
-    Windows; check [ImageView#146](https://github.com/
-    JuliaImages/ImageView.jl/issues/146) and
-    [ImageView#175](https://github.com/JuliaImages/ImageView.jl/issues/175) to get an update.
-
 ## Examples of usage
 
 If you feel ready to get started, see the [Demonstrations](@ref) page for inspiration.

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -307,7 +307,7 @@ Currently there're five julia packages can be used to display an image:
 
 * [`ImageShow`](https://github.com/JuliaImages/ImageShow.jl) is used to support image display in Juno and IJulia. This is automatically used when you use `Images`.
 * [`ImageInTerminal`](https://github.com/JuliaImages/ImageInTerminal.jl) is used to support image display in terminal.
-* [`ImageView`](https://github.com/JuliaImages/ImageView.jl) is an image display GUI.
+* [`ImageView`](https://github.com/JuliaImages/ImageView.jl) is an image display GUI. (For OSX and Windows platforms, Julia at least `v1.3` is required)
 * [`Plots`](https://github.com/JuliaPlots/Plots.jl) maintained by JuliaPlots is a general plotting package that support image display.
 * [`Makie`](https://github.com/JuliaPlots/Makie.jl) is also maintained by JuliaPlots but provides rich interactive functionality. 
 


### PR DESCRIPTION
@timholy With ImageView `0.10` released, I assume this is outdated now? Or, are OSX and Windows only works on Julia 1.3?