### PR TITLE
set travis timeout 20min

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ notifications:
   email: false
 script:
   - julia --project=. --color=yes -e 'using Pkg; Pkg.instantiate()'
-  - travis_wait 20 julia --project=. --color=yes docs/make.jl
+  - travis_wait 40 julia --project=. --color=yes docs/make.jl

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ notifications:
   email: false
 script:
   - julia --project=. --color=yes -e 'using Pkg; Pkg.instantiate()'
-  - julia --project=. --color=yes docs/make.jl
+  - travis_wait 20 julia --project=. --color=yes docs/make.jl


### PR DESCRIPTION
The previous documentation building CI fails because it exceeds the default timeout 10min, let's see how things work out if we set it to 20min.