### PR TITLE
Various updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: julia
 os:
   - linux
 julia:
-  - 1.0
+  - 1.3
 env:
   - DOCUMENTER_DEBUG=true
 notifications:

--- a/docs/src/api_comparison.md
+++ b/docs/src/api_comparison.md
@@ -25,11 +25,11 @@ welcome.
 | **Intensity & quantization**          |                                           |                                   |                                           |
 | Clamping                              | `clamp01`, `clamp01nan`                   |                                   |                                           |
 | Linear scaling                        | `scaleminmax`, `scalesigned`, etc.        | `rescale_intensity`               | `imadjust`                                |
-| Nonlinear scaling                     | `adjust_gamma`, `imstretch`               | `adjust_gamma`                    | `imadjust`                                |
-| Compute histogram                     | `imhist`                                  | `histogram`                       | `imhist`                                  |
-| Histogram equalization                | `histeq`                                  | `equalize_hist`                   | `histeq`                                  |
-| Adaptive equalization                 | `clahe`                                   | `equalize_adapthist`              | `adapthisteq`                             |
-| Reference histogram matching          | `histmatch`                               | `match_histograms`                | `imhistmatch`                             |
+| Nonlinear scaling                     | `GammaCorrection`, `imstretch`            | `adjust_gamma`                    | `imadjust`                                |
+| Compute histogram                     | `build_histogram`                         | `histogram`                       | `imhist`                                  |
+| Histogram equalization                | `adjust_histogram`                        | `equalize_hist`                   | `histeq`                                  |
+| Adaptive equalization                 | `AdaptiveEqualization`                    | `equalize_adapthist`              | `adapthisteq`                             |
+| Reference histogram matching          | `adjust_histogram`                        | `match_histograms`                | `imhistmatch`                             |
 | Quantization                          | map anonymous function                    |                                   | `imquantize`                              |
 | Threshold estimation                  | `otsu_threshold`                          | `threshold_otsu` etc.             | `graythresh` etc.                         |
 |                                       |                                           |                                   |                                           |

--- a/docs/src/conversions_views.md
+++ b/docs/src/conversions_views.md
@@ -395,12 +395,12 @@ julia> a2 = [1.0,2.0]'
 julia> a1p, a2p = paddedviews(0, a1, a2);   # 0 is the fill value
 
 julia> a1p
-2×2 PaddedViews.PaddedView{Int64,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}},Array{Int64,2}}:
+2×2 PaddedView(0, ::Array{Int64,2}, (Base.OneTo(2), Base.OneTo(2))) with eltype Int64:
  1  0
  2  0
 
 julia> a2p
-2×2 PaddedViews.PaddedView{Float64,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}},LinearAlgebra.Adjoint{Float64,Array{Float64,1}}}:
+2×2 PaddedView(0.0, ::LinearAlgebra.Adjoint{Float64,Array{Float64,1}}, (Base.OneTo(2), Base.OneTo(2))) with eltype Float64:
  1.0  2.0
  0.0  0.0
 ```

--- a/docs/src/function_reference.md
+++ b/docs/src/function_reference.md
@@ -220,23 +220,28 @@ findlocalminima
 ### Exposure
 
 ```@docs
-imhist
+build_histogram
+adjust_histogram
+adjust_histogram!
 cliphist
-histeq
-adjust_gamma
 imstretch
 imadjustintensity
 complement
-histmatch
-clahe
+AdaptiveEqualization
+GammaCorrection
 ```
 
 ### Spatial transformations and resizing
 
 ```@docs
 imresize
+imrotate
 restrict
 warp
+warpedview
+invwarpedview
+WarpedView
+InvWarpedView
 ```
 
 ### Image statistics
@@ -247,9 +252,10 @@ maxfinite
 maxabsfinite
 meanfinite
 ssd
-ssdn
+mse
 sad
-sadn
+mae
+entropy
 ```
 
 ### Morphological operations

--- a/docs/src/function_reference.md
+++ b/docs/src/function_reference.md
@@ -31,7 +31,10 @@ normedview
 rawview
 permuteddimsview
 StackedView
+PaddedView
 paddedviews
+sym_paddedviews
+StreamingContainer
 ```
 
 Images with defined geometry and axis meaning can be constructed using the [`AxisArrays`](https://github.com/JuliaArrays/AxisArrays.jl) package:
@@ -67,14 +70,22 @@ coords_spatial
 size_spatial
 indices_spatial
 nimages
+timeaxis
+istimeaxis
+timedim
 assert_timedim_last
+StreamIndexStyle
+IndexAny
+IndexIncremental
 ```
 
 ## Element transformation and intensity scaling
 
 ```@docs
 clamp01
+clamp01!
 clamp01nan
+clamp01nan!
 scaleminmax
 scalesigned
 colorsigned
@@ -93,6 +104,26 @@ n2f14
 n0f16
 ```
 
+## Color channels
+
+You can extract the numeric value of particular color channels:
+
+```@docs
+gray
+red
+green
+blue
+alpha
+```
+
+You can also perform operations on channels:
+
+```@docs
+mapc
+reducec
+mapreducec
+```
+
 ## Color conversion
 
 ```julia
@@ -105,6 +136,10 @@ calculates a grayscale representation of a color image using the
 imghsv = HSV.(img)
 ```
 converts to an HSV representation of color information.
+
+The [ColorTypes](https://github.com/JuliaGraphics/ColorTypes.jl)
+package has a rich set of traits that allow you to perform generic
+operations on color types, see its README for more information.
 
 ## Image algorithms
 
@@ -127,7 +162,10 @@ Kernel.ando5
 Kernel.gaussian
 Kernel.DoG
 Kernel.LoG
+Kernel.gabor
 Kernel.Laplacian
+Kernel.bickley
+Kernel.scharr
 ```
 
 #### KernelFactors
@@ -141,6 +179,8 @@ KernelFactors.ando5
 KernelFactors.gaussian
 KernelFactors.IIRGaussian
 KernelFactors.TriggsSdika
+KernelFactors.bickley
+KernelFactors.scharr
 ```
 
 #### Kernel utilities
@@ -194,6 +234,7 @@ magnitude_phase
 imedge
 thin_edges
 canny
+Percentile
 ```
 
 ### Corner Detection
@@ -277,6 +318,9 @@ component_subscripts
 component_centroids
 feature_transform
 distance_transform
+convexhull
+GuoAlgo
+thinning
 ```
 
 ### Interpolation
@@ -320,6 +364,7 @@ spatialproperties
 ```@docs
 SegmentedImage
 ImageEdge
+otsu_threshold
 labels_map
 segment_labels
 segment_pixel_count
@@ -340,6 +385,13 @@ region_splitting
 
 ## ImageFeatures
 
+### Geometric features
+
+```@docs
+hough_transform_standard
+hough_circle_gradient
+```
+
 ### Types
 
 ```@docs
@@ -351,6 +403,7 @@ BRIEF
 ORB
 FREAK
 BRISK
+HOG
 ```
 
 ### Corners

--- a/docs/src/function_reference.md
+++ b/docs/src/function_reference.md
@@ -208,7 +208,7 @@ fastcorners
 
 ### Feature Extraction
 
-See the [ImageFeatures]() package for a much more comprehensive set of tools.
+See the [ImageFeatures](https://juliaimages.org/ImageFeatures.jl/stable/) package for a much more comprehensive set of tools.
 
 ```@docs
 blob_LoG

--- a/docs/src/function_reference.md
+++ b/docs/src/function_reference.md
@@ -308,7 +308,7 @@ shepp_logan
 
 ```@docs
 ImageMeta
-data
+arraydata
 properties
 copyproperties
 shareproperties

--- a/docs/src/imagefeatures.md
+++ b/docs/src/imagefeatures.md
@@ -7,7 +7,7 @@ descriptors in other images or other portions of the same image. This
 can be useful in many applications, such as object recognition,
 localization, or image registration.
 
-ImagesFeatures has [its own documentation](http://juliaimages.github.io/ImageFeatures.jl/latest/index.html), and you should consult that for a comprehensive overview of the functionality of the package. Here, we'll briefly illustrate one type of feature and its application to image registration, the *BRISK* descriptor.
+ImagesFeatures has [its own documentation](https://juliaimages.org/ImageFeatures.jl/stable), and you should consult that for a comprehensive overview of the functionality of the package. Here, we'll briefly illustrate one type of feature and its application to image registration, the *BRISK* descriptor.
 
 The *BRISK* descriptor examines the structure of an image around a
 *keypoint*. Given a keypoint, the mean intensity (loosely-speaking) is

--- a/docs/src/imagemetadata.md
+++ b/docs/src/imagemetadata.md
@@ -52,10 +52,10 @@ RGB ImageMeta with:
     time: evening
 ```
 
-You can extract the data matrix with `data(img)`:
+You can extract the data matrix with `arraydata(img)`:
 
 ```jldoctest
-julia> data(img)
+julia> arraydata(img)
 3×2 Array{RGB{N0f8},2} with eltype RGB{FixedPointNumbers.Normed{UInt8,8}}:
  RGB{N0f8}(1.0,0.0,0.0)  RGB{N0f8}(1.0,0.0,0.0)
  RGB{N0f8}(1.0,0.0,0.0)  RGB{N0f8}(1.0,0.0,0.0)

--- a/docs/src/imagemetadata.md
+++ b/docs/src/imagemetadata.md
@@ -139,14 +139,14 @@ Int64 ImageMeta with:
   data: 3×5 reshape(::UnitRange{Int64}, 3, 5) with eltype Int64
   properties:
     maxsum: [42, 45]
-    spatialproperties: Set(Symbol[:maxsum])
+    spatialproperties: Set([:maxsum])
 
 julia> imgp = permutedims(img, (2,1))
 Int64 ImageMeta with:
   data: 5×3 Array{Int64,2}
   properties:
     maxsum: [45, 42]
-    spatialproperties: Set(Symbol[:maxsum])
+    spatialproperties: Set([:maxsum])
 
 julia> maximum(sum(imgp, dims=1))
 45

--- a/docs/src/indexing.md
+++ b/docs/src/indexing.md
@@ -34,7 +34,7 @@ julia> summary(img)
 "386×386 Array{Gray{N0f8},2} with eltype Gray{Normed{UInt8,8}}"
 
 julia> summary(imgrot)
-"OffsetArray(::Array{Gray{N0f8},2}, -59:446, -59:446) with eltype Gray{Normed{UInt8,8}} with indices -59:446×-59:446"
+"506×506 OffsetArray(::Array{Gray{N0f8},2}, -59:446, -59:446) with eltype Gray{Normed{UInt8,8}} with indices -59:446×-59:446"
 ```
 
 While `img` has axes that start with the conventional 1, the

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -328,7 +328,7 @@ Algorithms:
 - Resizing and spatial transformations: `restrict`, `imresize`, `warp`
 - Filtering: `imfilter`, `imfilter!`, `imfilter_LoG`, `mapwindow`, `imROF`, `padarray`
 - Filtering kernels: `Kernel.` or `KernelFactors.`, followed by `ando[345]`, `guassian2d`, `imaverage`, `imdog`, `imlaplacian`, `prewitt`, `sobel`
-- Exposure : `imhist`, `histeq`, `adjust_gamma`, `histmatch`, `imadjustintensity`, `imstretch`, `imcomplement`, `clahe`, `cliphist`
+- Exposure : `build_histogram`, `adjust_histogram`, `imadjustintensity`, `imstretch`, `imcomplement`, `AdaptiveEqualization`, `GammaCorrection`, `cliphist`
 - Gradients: `backdiffx`, `backdiffy`, `forwarddiffx`, `forwarddiffy`, `imgradients`
 - Edge detection: `imedge`, `imgradients`, `thin_edges`, `magnitude`, `phase`, `magnitudephase`, `orientation`, `canny`
 - Corner detection: `imcorner`, `harris`, `shi_tomasi`, `kitchen_rosenfeld`, `meancovs`, `gammacovs`, `fastcorners`

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -301,7 +301,7 @@ location across multiple images. More information can be found in
 
 ## Examples of usage
 
-If you feel ready to get started, see the [Demonstrations](@ref) page for inspiration.
+If you feel ready to get started, see the [Demonstrations](@ref demonstrations) page for inspiration.
 
 ## Function categories
 


### PR DESCRIPTION
This fixes quite a lot of the errors/warnings that get emitted when we build the docs. There are still many warnings about "potentially missing docstrings," but a lot of these are for internal functions (https://github.com/JuliaDocs/Documenter.jl/issues/600) or things that ColorTypes/Colors exports and which probably don't need to be documented here.

Some failures I have already fixed locally and will be fixed by the next releases of ColorTypes, PaddedViews, ImageMetadata, ImageSegmentation, and ImageContrastAdjustment.

There are also a few remaining oddities. @zygmuntszpak, for some reason it's not finding the docs for ImageContrastAdjustment. @johnnychen94, for some reason it's not finding the docs for `ssd`, `mse`, `sad`, and `mae`. I poked at these briefly but didn't quickly find the reason.