### PR TITLE
Clarified use

### DIFF
--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -49,7 +49,7 @@ Adding these gives you a basic image IO setup:
 and to load an image, you can use
 
 ```@example
-using FileIO
+using Images, FileIO
 using ImageShow # hide
 # specify the path to your local image file
 img_path = "/path/to/image.png"


### PR DESCRIPTION
`using Images` is necessary for examples on the following pages to work, but it's not shown explicitly here or on the next page. See also https://discourse.julialang.org/t/efficient-way-to-find-which-package-defines-an-unknown-type/42222