### PR TITLE
Made an example more illustrative

### DIFF
--- a/docs/src/tutorials/quickstart.md
+++ b/docs/src/tutorials/quickstart.md
@@ -17,7 +17,7 @@ make_roi(xs::UnitRange, ys::UnitRange) = make_roi(Point(ys[1], xs[1]), Point(ys[
 For most purposes, any `AbstractArray` can be treated as an image. For example, numeric array can be interpreted as a grayscale image.
 
 ```@repl array
-img = rand(4, 4)
+img = rand(4, 3)
 ```
 ```@example array
 Gray.(img) #hide


### PR DESCRIPTION
There is an issue of different canonical image orientations, e.g. https://discourse.julialang.org/t/different-image-orientation-in-images-vs-makie/42288. Making a matrix in this example non-square will alert the reader that Julia orients images (matrices) differently than some other programming environments.