### PR TITLE
fix the cover of rgb2gray demo

### DIFF
--- a/docs/examples/color_channels/rgb_grayscale.jl
+++ b/docs/examples/color_channels/rgb_grayscale.jl
@@ -1,6 +1,6 @@
 # ---
 # title: RGB to GrayScale
-# cover: assets/rgb_grayscale.png
+# cover: assets/rgb_grayscale.gif
 # ---
 
 # This example illustrates RGB to Grayscale Conversion
@@ -19,4 +19,5 @@ mosaicview(rgb_image, gray_image; nrow = 1)
 # [Rec. ITU-R BT.601-7](https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.601-7-201103-I!!PDF-E.pdf) rounding off to 3 decimal places 
 # `0.299 * R + 0.587 * G + 0.114 * B`
 
-save("assets/rgb_grayscale.png", gray_image) #src
+using ImageMagick #src
+ImageMagick.save("assets/rgb_grayscale.gif", cat(rgb_image, RGB.(gray_image); dims=3); fps=1) #src


### PR DESCRIPTION
Since #138 is going to be pended for a while, I give a quick fix here to #133

I instead use gif instead of png so that readers get a better view of the conversion from rgb to gray.

cc: @mgautam98 