### PR TITLE
permuteddimsview -> PermutedDimsArray

### DIFF
--- a/docs/src/function_reference.md
+++ b/docs/src/function_reference.md
@@ -72,7 +72,7 @@ Any of these operations may be composed together, e.g., if you have an
 metadata:
 
 ```julia
-img = ImageMeta(colorview(RGB, normedview(permuteddimsview(A, (3,1,2)))), sample="control")
+img = ImageMeta(colorview(RGB, normedview(PermutedDimsArray(A, (3,1,2)))), sample="control")
 ```
 
 ## Traits

--- a/docs/src/tutorials/quickstart.md
+++ b/docs/src/tutorials/quickstart.md
@@ -311,7 +311,7 @@ packages, which support a number of algorithms important for computer vision.
 Constructors, conversions, and traits:
 
 - Construction: use constructors of specialized packages, e.g., `AxisArray`, `ImageMeta`, etc.
-- "Conversion": `colorview`, `channelview`, `rawview`, `normedview`, `permuteddimsview`, `paddedviews`
+- "Conversion": `colorview`, `channelview`, `rawview`, `normedview`, `PermutedDimsArray`, `paddedviews`
 - Traits: `pixelspacing`, `sdims`, `timeaxis`, `timedim`, `spacedirections`
 
 Contrast/coloration:


### PR DESCRIPTION
## Summary
`permutteddimsview` is deprecated.

https://github.com/JuliaImages/ImageCore.jl/blob/c4d3bc959c1b9fe7fde5986edf443f7773d3943e/src/deprecations.jl#L88

We replace references to it with PermutedDimsArray.