### PR TITLE
remove extra space before the three-backticks

### DIFF
--- a/docs/src/tutorials/conversions_views.md
+++ b/docs/src/tutorials/conversions_views.md
@@ -252,7 +252,7 @@ Stacktrace:
  [1] error(::String) at .\error.jl:33
  [2] pointer_from_objref(::Any) at .\pointer.jl:146
  [3] top-level scope at none:1
- ```
+```
 
 The opposite transformation is `normedview`:
 


### PR DESCRIPTION
there is an extra space before the ending three-backticks of the code block, which causes an abnormal display in the webpage
![image](https://user-images.githubusercontent.com/13688320/101434184-8ad9fa80-3945-11eb-9d8f-7895cf2c0505.png)
