### PR TITLE
houseclean: forcepush when deploying documentation

### DIFF
--- a/.github/workflows/DocCleanup.yml
+++ b/.github/workflows/DocCleanup.yml
@@ -1,0 +1,29 @@
+# This workflow was taken from CliMA/TimeMachine.jl (Apache License 2.0).
+# Change note:
+#   JuliaImages documentation somehow uses master branch instead of gh-pages branch.
+name: Doc Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  doc-preview-cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master branch
+        uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: Delete preview and history + push changes
+        run: |
+            if [ -d "previews/PR$PRNUM" ]; then
+              git config user.name "Documenter.jl"
+              git config user.email "documenter@juliadocs.github.io"
+              git rm -rf "previews/PR$PRNUM"
+              git commit -m "delete preview"
+              git branch master-new $(echo "delete history" | git commit-tree HEAD^{tree})
+              git push --force origin master-new:master
+            fi
+        env:
+            PRNUM: ${{ github.event.number }}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -47,6 +47,7 @@ deploydocs(repo      = "github.com/JuliaImages/juliaimages.github.io.git",
            target    = "build",
            branch    = branch,
            push_preview = true,
+           forcepush = true,
            devbranch = "source",
            deps      = nothing,
            make      = nothing)


### PR DESCRIPTION
I've manually compressed the git history in the master branch, this is the next step to make sure the history doesn't grow that fast.

closes #211 