### PR TITLE
Fix typo in mosaicview in closing morphology example

### DIFF
--- a/docs/examples/image_morphology/image_morphology.jl
+++ b/docs/examples/image_morphology/image_morphology.jl
@@ -89,7 +89,7 @@ mosaicview(img_opening, img_opening1, img_opening2; nrow = 1)
 img_closing = @. Gray(1 * img > 0.5);
 img_closing1 = closing(img_closing)
 img_closing2 = closing(closing(img_closing))
-mosaicview(img_closing1, img_closing1, img_closing2; nrow = 1)
+mosaicview(img_closing, img_closing1, img_closing2; nrow = 1)
 
 # ## Tophat
 


### PR DESCRIPTION
In the closing morphology example mosaicview (line 92) shows img_closing1 twice, it should show the 3 images (img_closing, img_closing1 & img_closing2)